### PR TITLE
Fixing Aruba helpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem 'aruba'
+gem 'aruba', github: 'cucumber/aruba', ref: 'b9d0f15d1292697b051f94984925b4f63c4efac4'
 gem 'docker-api', require: 'docker'
 gem 'pry'
 gem 'pry-coolline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: https://github.com/cucumber/aruba.git
+  revision: b9d0f15d1292697b051f94984925b4f63c4efac4
+  ref: b9d0f15d1292697b051f94984925b4f63c4efac4
   specs:
     aruba (2.2.0)
       bundler (>= 1.17, < 3.0)
@@ -7,8 +9,12 @@ GEM
       cucumber (>= 8.0, < 10.0)
       rspec-expectations (~> 3.4)
       thor (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
     builder (3.2.4)
-    coderay (1.1.2)
+    coderay (1.1.3)
     contracts (0.17)
     coolline (0.5.0)
       unicode_utils (~> 1.4)
@@ -37,20 +43,21 @@ GEM
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (5.0.6)
     diff-lcs (1.5.0)
-    docker-api (1.34.2)
+    docker-api (2.2.0)
       excon (>= 0.47.0)
       multi_json
-    excon (0.71.0)
+    excon (0.109.0)
     ffi (1.16.3)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_mime (1.1.5)
     multi_json (1.15.0)
     multi_test (1.1.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-coolline (0.2.5)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-coolline (0.2.6)
       coolline (~> 0.5)
+      pry (~> 0.13)
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
@@ -64,7 +71,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aruba
+  aruba!
   docker-api
   ffi (= 1.16.3)
   pry

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,0 +1,1 @@
+default: --color --format pretty --publish-quiet

--- a/features/cleanup_command.feature
+++ b/features/cleanup_command.feature
@@ -2,17 +2,16 @@ Feature: Cleanup Command
 
   Background:
     Given I have "go" command installed
+    And a build of gitsweeper
     And I have "docker" command installed
     And nothings running on port "8008"
-    When I run `go build -o ../../bin/gitsweeper-int-test ../../main.go`
-    Then the exit status should be 0
 
   Scenario: In a git repo with branches with force
     Given no old "gitdocker" containers exist
     And I have a dummy git server running called "gitdocker" running on port "8008"
     And I clone "http://localhost:8008/dummy-repo.git" repo
     And I cd to "dummy-repo"
-    When I run `bin/gitsweeper-int-test cleanup --force`
+    When I run `gitsweeper-int-test cleanup --force`
     Then the output should contain:
       """
       These branches have been merged into master:
@@ -24,24 +23,12 @@ Feature: Cleanup Command
       """
     And the exit status should be 0
 
-  Scenario: In a git repo with a origin new_origin
-    Given no old "gitdocker" containers exist
-    And I have a dummy git server running called "gitdocker" running on port "8008"
-    And I clone "http://localhost:8008/dummy-repo.git" repo
-    And I cd to "dummy-repo"
-    When I run `git remote -v`
-    Then the output should contain:
-      """
-      FOO
-      """
-    And the exit status should be 0
-
   Scenario: In a git repo with branches with prompt yes
     Given no old "gitdocker" containers exist
     And I have a dummy git server running called "gitdocker" running on port "8008"
     And I clone "http://localhost:8008/dummy-repo.git" repo
     And I cd to "dummy-repo"
-    When I run `bin/gitsweeper-int-test cleanup` interactively
+    When I run `gitsweeper-int-test cleanup` interactively
     And I type "y"
     Then the output should contain:
       """
@@ -59,7 +46,7 @@ Feature: Cleanup Command
     And I have a dummy git server running called "gitdocker" running on port "8008"
     And I clone "http://localhost:8008/dummy-repo.git" repo
     And I cd to "dummy-repo"
-    When I run `bin/gitsweeper-int-test cleanup` interactively
+    When I run `gitsweeper-int-test cleanup` interactively
     And I type "n"
     Then the output should contain:
       """
@@ -73,10 +60,9 @@ Feature: Cleanup Command
   Scenario: In a non-git repo
     Given I run `mkdir -p not-a-git-repo`
     And I cd to "not-a-git-repo"
-    When I run `bin/gitsweeper-int-test cleanup`
+    When I run `gitsweeper-int-test cleanup`
     Then the output should contain:
       """
-
       gitsweeper-int-test: error: Error when looking for branches repository does not exist
       """
     And the exit status should be 1

--- a/features/no_argument.feature
+++ b/features/no_argument.feature
@@ -2,12 +2,12 @@ Feature: Version Command
 
   Background:
     Given I have "go" command installed
-    When I run `go build -o ../../bin/gitsweeper-int-test ../../main.go`
-    Then the exit status should be 0
+    And a build of gitsweeper
+    Then the build should be present
 
   Scenario:
     Given a build of gitsweeper
-    When I run `bin/gitsweeper-int-test`
+    When I run `gitsweeper-int-test`
     Then the output should contain:
       """"
       usage: gitsweeper [<flags>] <command> [<args> ...]

--- a/features/preview_command.feature
+++ b/features/preview_command.feature
@@ -2,16 +2,14 @@ Feature: Preview Command
 
   Background:
     Given I have "go" command installed
-    When I run `go build -o ../../bin/gitsweeper-int-test ../../main.go`
-    Then the exit status should be 0
+    And a build of gitsweeper
 
   Scenario: In a Git repo with branches
-    Given I clone "git://github.com/petems/example-repo-with-remote-branches.git" repo
+    Given I clone "https://github.com/petems/example-repo-with-remote-branches.git" repo
     And I cd to "example-repo-with-remote-branches"
-    When I run `bin/gitsweeper-int-test preview`
+    When I run `gitsweeper-int-test preview`
     Then the output should contain:
       """
-
       Fetching from the remote...
 
       These branches have been merged into master:
@@ -22,29 +20,29 @@ Feature: Preview Command
     And the exit status should be 0
 
   Scenario: In a Git repo with branches and debug enabled
-    Given I clone "git://github.com/petems/example-repo-with-remote-branches.git" repo
+    Given I clone "https://github.com/petems/example-repo-with-remote-branches.git" repo
     And I cd to "example-repo-with-remote-branches"
-    When I run `bin/gitsweeper-int-test --debug preview`
+    When I run `gitsweeper-int-test --debug preview`
     Then the output should contain "Branch origin/branch_thats_been_merged_to_master head (574d05288ddb0449402829e90b5752d78a7f54d7) was found in master, so has been merged!"
     And the exit status should be 0
 
   Scenario: In a non-git repo
     Given I run `mkdir -p not-a-git-repo`
     And I cd to "not-a-git-repo"
-    When I run `bin/gitsweeper-int-test preview`
+    When I run `gitsweeper-int-test preview`
     Then the output should match /This is not a Git repository/
     And the exit status should be 1
 
   Scenario: In a non-git repo
     Given I create a bare git repo called "bare-git-repo"
     And I cd to "bare-git-repo"
-    When I run `bin/gitsweeper-int-test preview`
+    When I run `gitsweeper-int-test preview`
     Then the output should match /Could not find the remote named origin/
     And the exit status should be 1
 
   Scenario: Using a non-existant remote
-    Given I clone "git://github.com/petems/example-repo-with-remote-branches.git" repo
+    Given I clone "https://github.com/petems/example-repo-with-remote-branches.git" repo
     And I cd to "example-repo-with-remote-branches"
-    When I run `bin/gitsweeper-int-test preview --origin=notexist`
+    When I run `gitsweeper-int-test preview --origin=notexist`
     Then the output should match /Could not find the remote named notexist/
     And the exit status should be 1

--- a/features/step_definitions/gitsweeper_steps.rb
+++ b/features/step_definitions/gitsweeper_steps.rb
@@ -5,8 +5,14 @@ Given(/^I have "([^"]*)" command installed$/) do |command|
   raise "Command #{command} is not present in the system" if not is_present
 end
 
-Given("a build of gitsweeper") do
+Then('the build should be present') do
+  steps %Q(
+    Then a file named "#{$bin_dir}/gitsweeper-int-test" should exist
+  )
+end
 
+Given("a build of gitsweeper") do
+  raise 'gitsweeper build failed' unless system("go build -o bin/gitsweeper-int-test main.go")
 end
 
 Given(/nothings running on port "(\w+)"/) do |port|
@@ -31,9 +37,13 @@ Given /^I have a dummy git server running called "(\w+)" running on port "(\w+)"
 end
 
 Given(/I clone "([^"]*)" repo/) do |repo_name|
-  run_silent %(git clone #{repo_name})
+  steps %Q(
+    When I successfully run `git clone #{repo_name}`
+  )
 end
 
 Given(/I create a bare git repo called "([^"]*)"/) do |repo_name|
-  run_silent %(git init --bare #{repo_name})
+  steps %Q(
+    When I successfully run `git init --bare #{repo_name}`
+  )
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,14 +4,25 @@ require 'fileutils'
 require 'forwardable'
 require 'tmpdir'
 
-bin_dir = File.expand_path('../fakebin', __FILE__)
-aruba_dir = File.expand_path('../../..', __FILE__) + '/tmp/aruba'
+$bin_dir = File.expand_path('../../../bin/', __FILE__)
+$aruba_dir = File.expand_path('../../..', __FILE__) + '/tmp/aruba'
+
+Aruba.configure do |config|
+  # increase process exit timeout from the default of 3 seconds
+  config.exit_timeout = 20
+  # allow absolute paths for tests involving no repo
+  config.allow_absolute_paths = true
+  # don't be "helpful"
+  config.remove_ansi_escape_sequences = false
+end
 
 Before do
-  # increase process exit timeout from the default of 3 seconds
-  @aruba_timeout_seconds = 10
-  # don't be "helpful"
-  @aruba_keep_ansi = true
+  aruba.environment.update(
+    'PATH' => "#{$bin_dir}:#{ENV['PATH']}",
+  )
+  FileUtils.rm_rf("#{$aruba_dir}/bare-git-repo")
+  FileUtils.rm_rf("#{$aruba_dir}/dummy-repo")
+  FileUtils.rm_rf("#{$bin_dir}/gitsweeper-int-test")
 end
 
 After do
@@ -20,83 +31,7 @@ After do
     app.delete(force: true)
   rescue Docker::Error::NotFoundError
   end
-  FileUtils.rm_rf("#{aruba_dir}/bare-git-repo")
+  FileUtils.rm_rf("#{$aruba_dir}/bare-git-repo")
+  FileUtils.rm_rf("#{$aruba_dir}/dummy-repo")
+  FileUtils.rm_rf("#{$bin_dir}/gitsweeper-int-test")
 end
-
-RSpec::Matchers.define :be_successful_command do
-  match do |cmd|
-    cmd.success?
-  end
-
-  failure_message do |cmd|
-    %(command "#{cmd}" exited with status #{cmd.status}:) <<
-      cmd.output.gsub(/^/, ' ' * 2)
-  end
-end
-
-class SimpleCommand
-  attr_reader :output
-  extend Forwardable
-
-  def_delegator :@status, :exitstatus, :status
-  def_delegators :@status, :success?
-
-  def initialize cmd
-    @cmd = cmd
-  end
-
-  def to_s
-    @cmd
-  end
-
-  def self.run cmd
-    command = new(cmd)
-    command.run
-    command
-  end
-
-  def run
-    @output = `#{@cmd} 2>&1`.chomp
-    @status = $?
-    $?.success?
-  end
-end
-
-World Module.new {
-  # If there are multiple inputs, e.g., type in username and then type in password etc.,
-  # the Go program will freeze on the second input. Giving it a small time interval
-  # temporarily solves the problem.
-  # See https://github.com/cucumber/aruba/blob/7afbc5c0cbae9c9a946d70c4c2735ccb86e00f08/lib/aruba/api.rb#L379-L382
-  def type(*args)
-    super.tap { sleep 0.1 }
-  end
-
-  def run_silent cmd
-    in_current_dir do
-      command = SimpleCommand.run(cmd)
-      expect(command).to be_successful_command
-      command.output
-    end
-  end
-
-  # Aruba unnecessarily creates new Announcer instance on each invocation
-  def announcer
-    @announcer ||= super
-  end
-
-  def shell_escape(message)
-    message.to_s.gsub(/['"\\ $]/) { |m| "\\#{m}" }
-  end
-
-  %w[output_from stdout_from stderr_from all_stdout all_stderr].each do |m|
-    define_method(m) do |*args|
-      home = ENV['HOME'].to_s
-      output = super(*args)
-      if home.empty?
-        output
-      else
-        output.gsub(home, '$HOME')
-      end
-    end
-  end
-}

--- a/features/version_command.feature
+++ b/features/version_command.feature
@@ -1,20 +1,14 @@
 Feature: Version Command
 
-  Background:
-    Given I have "go" command installed
-    When I run `go build -o ../../bin/gitsweeper-int-test ../../main.go`
-    Then the exit status should be 0
-
   Scenario: Version with no flags
     Given a build of gitsweeper
-    When I run `bin/gitsweeper-int-test version`
+    When I run `gitsweeper-int-test version`
     Then the output should contain exactly:
       """""
-
       0.1.0 development
       """""
 
   Scenario: Version with --debug flag
     Given a build of gitsweeper
-    When I run `bin/gitsweeper-int-test --debug version`
+    When I run `gitsweeper-int-test --debug version`
     Then the output should match /--debug setting detected - Info level logs enabled/


### PR DESCRIPTION
* removing cruft that was mostly copy-pasted
* updating out of date methods for timeouts etc
* Fixing pathing
* delete old builds after each run to be sure
* using new `a build of gitsweeper` for background
* change commands to use path