### PR TITLE
Squash Aruba tests to just 3.3 Ruby

### DIFF
--- a/.github/workflows/aruba.yml
+++ b/.github/workflows/aruba.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        # ruby-version: ['3.0', '3.1', '3.2'] # overkill
+        ruby-version: ['3.3']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
* Might as well stick with non EOL