### PR TITLE
Fixing the --origin option

### DIFF
--- a/.github/workflows/aruba.yml
+++ b/.github/workflows/aruba.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         # ruby-version: ['3.0', '3.1', '3.2'] # overkill
         ruby-version: ['3.3']
+        go-version: [ '1.21.x' ]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -24,5 +25,7 @@ jobs:
       run: docker pull petems/dummy-git-repo
     - name: Bundler
       run: bundle install
+    - name: Setup Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v4
     - name: Cucumber
       run: bundle exec cucumber

--- a/features/cleanup_command.feature
+++ b/features/cleanup_command.feature
@@ -18,8 +18,8 @@ Feature: Cleanup Command
         origin/duplicate-branch-1
         origin/duplicate-branch-2
       
-        deleting duplicate-branch-1 - (done)
-        deleting duplicate-branch-2 - (done)
+        deleting origin/duplicate-branch-1 - (done)
+        deleting origin/duplicate-branch-2 - (done)
       """
     And the exit status should be 0
 
@@ -36,8 +36,8 @@ Feature: Cleanup Command
         origin/duplicate-branch-1
         origin/duplicate-branch-2
       Delete these branches? [y/n]: 
-        deleting duplicate-branch-1 - (done)
-        deleting duplicate-branch-2 - (done)
+        deleting origin/duplicate-branch-1 - (done)
+        deleting origin/duplicate-branch-2 - (done)
       """
     And the exit status should be 0
   
@@ -66,3 +66,23 @@ Feature: Cleanup Command
       gitsweeper-int-test: error: Error when looking for branches repository does not exist
       """
     And the exit status should be 1
+
+  Scenario: Specifying a remote with multiple remotes
+    Given no old "gitdocker" containers exist
+    And I have a dummy git server running called "gitdocker" running on port "8008"
+    And I clone "http://localhost:8008/dummy-repo.git" repo
+    And I cd to "dummy-repo"
+    And I add a new remote "new_remote" with url "http://localhost:8008/dummy-repo.git"
+    When I run `gitsweeper-int-test cleanup --origin=new_remote --force`
+    Then the output should contain:
+      """
+      Fetching from the remote...
+
+      These branches have been merged into master:
+        new_remote/duplicate-branch-1
+        new_remote/duplicate-branch-2
+
+        deleting new_remote/duplicate-branch-1 - (done)
+        deleting new_remote/duplicate-branch-2 - (done)
+      """
+    And the exit status should be 0

--- a/features/preview_command.feature
+++ b/features/preview_command.feature
@@ -53,3 +53,22 @@ Feature: Preview Command
     When I run `gitsweeper-int-test preview --origin=notexist`
     Then the output should match /Could not find the remote named notexist/
     And the exit status should be 1
+
+  Scenario: Specifying a remote with multiple remotes
+    Given no old "gitdocker" containers exist
+    And I have a dummy git server running called "gitdocker" running on port "8008"
+    And I clone "http://localhost:8008/dummy-repo.git" repo
+    And I cd to "dummy-repo"
+    And I add a new remote "new_remote" with url "http://localhost:8008/dummy-repo.git"
+    When I run `gitsweeper-int-test preview --origin=new_remote`
+    Then the output should contain:
+      """
+      Fetching from the remote...
+
+      These branches have been merged into master:
+        new_remote/duplicate-branch-1
+        new_remote/duplicate-branch-2
+
+      To delete them, run again with `gitsweeper cleanup`
+      """
+    And the exit status should be 0

--- a/features/step_definitions/gitsweeper_steps.rb
+++ b/features/step_definitions/gitsweeper_steps.rb
@@ -47,3 +47,10 @@ Given(/I create a bare git repo called "([^"]*)"/) do |repo_name|
     When I successfully run `git init --bare #{repo_name}`
   )
 end
+
+Given /^I add a new remote "([^"]*)" with url "([^"]*)"$/ do |new_remote, url|
+  steps %Q(
+    When I successfully run `git remote add #{new_remote} #{url}`
+    And I successfully run `git fetch #{new_remote}`
+  )
+end

--- a/internal/githelpers.go
+++ b/internal/githelpers.go
@@ -156,11 +156,19 @@ func GetMergedBranches(remoteOrigin, masterBranchName, skipBranches string) ([]s
 
 	delete(remoteBranchHeads, masterBranchRemote)
 
+	log.Infof("Origin has been set to '%s', restricting branches to preview to that origin", remoteOrigin)
+
 	err = masterCommits.ForEach(func(commit *object.Commit) error {
 		for branchName, branchHead := range remoteBranchHeads {
-			if branchHead.String() == commit.Hash.String() {
-				log.Infof("Branch %s head (%s) was found in master, so has been merged!\n", branchName, branchHead)
-				mergedBranches = append(mergedBranches, branchName)
+			remote, _ := ParseBranchname(branchName)
+			if remote == remoteOrigin {
+				log.Infof("Branch '%s' matches remote '%s'", branchName, remoteOrigin)
+				if branchHead.String() == commit.Hash.String() {
+					log.Infof("Branch %s head (%s) was found in master, so has been merged!\n", branchName, branchHead)
+					mergedBranches = append(mergedBranches, branchName)
+				}
+			} else {
+				log.Infof("Branch '%s' does not match remote '%s', not adding to", branchName, remoteOrigin)
 			}
 		}
 		return nil

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 			fmt.Printf("\n")
 			for _, branchName := range mergedBranches {
 				remote, branchShort := hlpr.ParseBranchname(branchName)
-				fmt.Printf("  deleting %s", branchShort)
+				fmt.Printf("  deleting %s", branchName)
 				repo, _ := hlpr.GetCurrentDirAsGitRepo()
 				err := hlpr.DeleteBranch(repo, remote, branchShort)
 				if err != nil {


### PR DESCRIPTION
* basically was always ignored previously (which is actually the git-sweep behaviour)
* I think it makes more sense to stick with clearing just one remote if listed
* added tests to validate and changed in line with the new output that will have the remote and branch name