### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test (${{ matrix.go-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/petems/gitsweeper/security/code-scanning/1](https://github.com/petems/gitsweeper/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only performs read operations (e.g., checking out code, installing dependencies, building, and testing), we will set the `contents` permission to `read`. This ensures that the workflow has the minimal permissions required to function correctly.

The `permissions` block will be added at the root level of the workflow, so it applies to all jobs. This approach is cleaner and avoids redundancy if additional jobs are added in the future.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
