### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/install-script-validation.yml
+++ b/.github/workflows/install-script-validation.yml
@@ -137,6 +137,8 @@ jobs:
 
   cross-platform:
     name: Cross-Platform Testing
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/petems/gitsweeper/security/code-scanning/9](https://github.com/petems/gitsweeper/security/code-scanning/9)

To fix the problem, add an explicit `permissions` block to the `cross-platform` job in `.github/workflows/install-script-validation.yml`. This block should restrict the GITHUB_TOKEN to only the permissions required for the job. Since the job only checks out code and runs tests, it only needs read access to repository contents. Add the following under the `cross-platform` job definition (line 139):  
```yaml
permissions:
  contents: read
```
No additional imports, methods, or definitions are needed. This change is limited to the YAML workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
