### PR TITLE
fix: use configurable master branch name in remote branch filtering

### DIFF
--- a/internal/githelpers.go
+++ b/internal/githelpers.go
@@ -157,7 +157,7 @@ func GetMergedBranches(remoteOrigin, masterBranchName, skipBranches string) ([]s
 	}
 
 	// Get remote branches efficiently
-	remoteBranches, err := getRemoteBranchesOptimized(repo, remoteOrigin, skipSet)
+	remoteBranches, err := getRemoteBranchesOptimized(repo, remoteOrigin, masterBranchName, skipSet)
 	if err != nil {
 		return nil, err
 	}
@@ -205,6 +205,7 @@ func getBranchHeadsOptimized(repo *git.Repository) (map[string]plumbing.Hash, er
 func getRemoteBranchesOptimized(
 	repo *git.Repository,
 	remoteOrigin string,
+	masterBranchName string,
 	skipSet map[string]bool,
 ) ([]BranchInfo, error) {
 	remoteBranches, err := RemoteBranches(repo.Storer)
@@ -213,7 +214,7 @@ func getRemoteBranchesOptimized(
 	}
 
 	var branches []BranchInfo
-	masterBranchRemote := fmt.Sprintf("%s/%s", remoteOrigin, "master")
+	masterBranchRemote := fmt.Sprintf("%s/%s", remoteOrigin, masterBranchName)
 
 	err = remoteBranches.ForEach(func(branch *plumbing.Reference) error {
 		remoteBranchName := strings.TrimPrefix(branch.Name().String(), "refs/remotes/")

--- a/internal/githelpers_test.go
+++ b/internal/githelpers_test.go
@@ -3,6 +3,10 @@ package internal
 import (
 	"testing"
 
+	memfs "github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,4 +36,22 @@ func TestParseBranchname_ThreeSlashes(t *testing.T) {
 
 	assert.Equal(t, "origin", remote)
 	assert.Equal(t, "janedoe/cool-branch-name/and-another-branch-after/one-more-for-luck", branchShort)
+}
+
+func TestGetRemoteBranchesOptimizedSkipsCustomMaster(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	assert.NoError(t, err)
+
+	masterHash := plumbing.NewHash("1111111111111111111111111111111111111111")
+	featureHash := plumbing.NewHash("2222222222222222222222222222222222222222")
+
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/main"), masterHash))
+	assert.NoError(t, err)
+	err = repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName("refs/remotes/origin/feature-branch"), featureHash))
+	assert.NoError(t, err)
+
+	branches, err := getRemoteBranchesOptimized(repo, "origin", "main", map[string]bool{})
+	assert.NoError(t, err)
+	assert.Len(t, branches, 1)
+	assert.Equal(t, "origin/feature-branch", branches[0].Name)
 }


### PR DESCRIPTION
- Add masterBranchName parameter to getRemoteBranchesOptimized function
- Replace hardcoded "master" with configurable master branch name
- Add test coverage for custom master branch filtering
- Ensures proper branch filtering when using non-standard master branch names

🤖 Generated with [Claude Code](https://claude.ai/code)