### PR TITLE
Add Codecov configuration with 90% coverage target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    # Overall project coverage
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+        informational: false
+
+    # Coverage for changes in a PR
+    patch:
+      default:
+        target: 90%
+        threshold: 1%
+        informational: false
+
+# Comment configuration
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -26,3 +26,9 @@ comment:
   layout: "reach,diff,flags,tree"
   behavior: default
   require_changes: false
+
+# Ignore generated files from coverage reports
+ignore:
+  - "**/*.pb.go"      # Protocol buffer generated files
+  - "vendor/**"       # Vendored dependencies
+  - "bin/**"          # Built binaries


### PR DESCRIPTION
## Summary
- Adds `.codecov.yml` configuration file
- Sets 90% coverage target for both project and patch coverage
- Includes 1% threshold allowance to prevent false failures
- Enables blocking status checks to maintain code quality standards

## Details
This configuration ensures that:
- Overall project coverage maintains at least 90% (with 1% threshold)
- New code in PRs also maintains 90% coverage
- Coverage reports include detailed metrics with 2 decimal precision
- Status checks are blocking (not informational only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added project code coverage configuration to enable automated coverage reporting and PR feedback formatting (coverage thresholds, report layout, and ignore rules for generated/vendor/binary files).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->